### PR TITLE
Create TabGroup.kt from IOS

### DIFF
--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
@@ -1,6 +1,5 @@
 package dev.slne.surf.tab.api.model
 
-import dev.slne.surf.tab.api.model.TabServer
 import it.unimi.dsi.fastutil.objects.ObjectSet
 
 interface TabGroup {

--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.tab.api.model
+
+import dev.slne.surf.tab.api.model.TabServer
+
+interface TabGroup {
+  val name: String
+  val display: String
+
+  val servers: ObjectSet<TabServer>
+}

--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/model/TabGroup.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.tab.api.model
 
 import dev.slne.surf.tab.api.model.TabServer
+import it.unimi.dsi.fastutil.objects.ObjectSet
 
 interface TabGroup {
   val name: String


### PR DESCRIPTION
This pull request introduces a new interface, `TabGroup`, to the codebase. The interface defines the properties required for a tab group, including its name, display name, and a set of associated servers.

New model addition:

* Added a new interface `TabGroup` in `TabGroup.kt` with properties for `name`, `display`, and a set of `TabServer` instances.