### PR TITLE
Feat/velocity based sorting

### DIFF
--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/TabEntry.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/TabEntry.kt
@@ -1,12 +1,11 @@
 package dev.slne.surf.tab.api
 
+import dev.slne.surf.tab.api.auth.TabGameProfile
 import dev.slne.surf.tab.api.player.TabGameMode
 import net.kyori.adventure.text.Component
-import java.util.*
 
 interface TabEntry {
-    val associatedName: String
-    val associatedPlayer: UUID
+    val profile: TabGameProfile
     val display: Component
     val gameMode: TabGameMode
     val ping: Int

--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/auth/TabGameProfile.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/auth/TabGameProfile.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.tab.api.auth
+
+import it.unimi.dsi.fastutil.objects.ObjectSet
+import java.util.*
+
+data class TabGameProfile(
+    val uuid: UUID,
+    val name: String,
+    val properties: ObjectSet<TabProperty>
+)

--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/auth/TabProperty.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/auth/TabProperty.kt
@@ -1,0 +1,7 @@
+package dev.slne.surf.tab.api.auth
+
+data class TabProperty(
+    val name: String,
+    val value: String,
+    val signature: String
+)

--- a/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/player/TabGameMode.kt
+++ b/surf-tab-api/src/main/kotlin/dev/slne/surf/tab/api/player/TabGameMode.kt
@@ -1,8 +1,8 @@
 package dev.slne.surf.tab.api.player
 
-enum class TabGameMode {
-    CREATIVE,
-    SURVIVAL,
-    ADVENTURE,
-    SPECTATOR
+enum class TabGameMode(val index: Int) {
+    CREATIVE(1),
+    SURVIVAL(0),
+    ADVENTURE(2),
+    SPECTATOR(3)
 }

--- a/surf-tab-core/src/main/kotlin/dev/slne/surf/tab/core/model/TabEntryImpl.kt
+++ b/surf-tab-core/src/main/kotlin/dev/slne/surf/tab/core/model/TabEntryImpl.kt
@@ -1,13 +1,12 @@
 package dev.slne.surf.tab.core.model
 
 import dev.slne.surf.tab.api.TabEntry
+import dev.slne.surf.tab.api.auth.TabGameProfile
 import dev.slne.surf.tab.api.player.TabGameMode
 import net.kyori.adventure.text.Component
-import java.util.*
 
 data class TabEntryImpl(
-    override val associatedPlayer: UUID,
-    override val associatedName: String,
+    override val profile: TabGameProfile,
     override val display: Component,
     override val gameMode: TabGameMode,
     override val ping: Int,

--- a/surf-tab-core/src/main/kotlin/dev/slne/surf/tab/core/service/TabService.kt
+++ b/surf-tab-core/src/main/kotlin/dev/slne/surf/tab/core/service/TabService.kt
@@ -18,8 +18,8 @@ interface TabService {
     fun showEntries(player: TabPlayer, entries: ObjectSet<TabEntry>) =
         entries.forEach { showEntry(player, it) }
 
-    fun hideEntry(player: TabPlayer, entry: TabEntry)
-    fun hideEntries(player: TabPlayer, entries: ObjectSet<TabEntry>) =
+    fun hideEntry(player: TabPlayer, entry: UUID)
+    fun hideEntries(player: TabPlayer, entries: ObjectSet<UUID>) =
         entries.forEach { hideEntry(player, it) }
 
     fun updateEntry(player: TabPlayer, associatedWithEntry: UUID)

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/config/TabConfig.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/config/TabConfig.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.tab.velocity.config
 
 import dev.slne.surf.surfapi.core.api.messages.Colors
+import dev.slne.surf.tab.api.TabDisplayMode
 import dev.slne.surf.tab.velocity.util.mm
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
 
@@ -9,5 +10,5 @@ data class TabConfig(
     val header: String = "<br>LOGO<br><br>${Colors.INFO.mm()}%localtime_time_dd:MM:yyyy% ${Colors.SPACER.mm()}-${Colors.INFO.mm()} %localtime_time_HH:mm:ss% ${Colors.SPACER.mm()}<> ${Colors.INFO.mm()}%server_online% ${Colors.SPACER.mm()}/ ${Colors.INFO.mm()}%server_max_online%<br><br>",
     val footer: String = "<br><br>${Colors.INFO.mm()}Server${Colors.SPACER.mm()}: ${Colors.VARIABLE_VALUE.mm()}IDK <br><br>%player_ping%ms ${Colors.SPACER.mm()}<> %server_tps_1_colored% ${Colors.SPACER.mm()}/ %server_tps_5_colored% ${Colors.SPACER.mm()}/ %server_tps_15_colored%<br><br><br>",
     val displayName: String = "%luckperms_prefix% %player_name% %luckperms_suffix%",
-    val displayMode: String = ""
+    val displayMode: TabDisplayMode = TabDisplayMode.PER_PROXY
 )

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/config/TabConfigProvider.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/config/TabConfigProvider.kt
@@ -2,6 +2,8 @@ package dev.slne.surf.tab.velocity.config
 
 import dev.slne.surf.surfapi.core.api.config.manager.SpongeConfigManager
 import dev.slne.surf.surfapi.core.api.config.surfConfigApi
+import dev.slne.surf.surfapi.core.api.util.logger
+import dev.slne.surf.tab.api.TabDisplayMode
 import dev.slne.surf.tab.velocity.plugin
 
 class TabConfigProvider {
@@ -16,6 +18,12 @@ class TabConfigProvider {
 
     fun reload() {
         configManager.reloadFromFile()
+
+        if (config().displayMode == TabDisplayMode.CLOUD_GLOBAL || config().displayMode == TabDisplayMode.PER_WORLD) {
+            logger().atWarning()
+                .log("TabDisplayMode ${config().displayMode} is not supported on Velocity, switching to PER_PROXY")
+            configManager.config = configManager.config.copy(displayMode = TabDisplayMode.PER_PROXY)
+        }
     }
 
     fun config() = configManager.config

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/listener/ConnectionListener.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/listener/ConnectionListener.kt
@@ -1,16 +1,24 @@
 package dev.slne.surf.tab.velocity.listener
 
+import com.github.shynixn.mccoroutine.velocity.launch
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.player.ServerPostConnectEvent
 import dev.slne.surf.tab.core.service.tabService
+import dev.slne.surf.tab.velocity.container
+import dev.slne.surf.tab.velocity.plugin
 import dev.slne.surf.tab.velocity.util.tabPlayer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 
 class ConnectionListener {
     @Subscribe
     fun onConnect(event: ServerPostConnectEvent) {
-        val player = event.player
-        val tabPlayer = player.tabPlayer()
+        container.launch(Dispatchers.IO) {
+            delay(50)
 
-        tabService.sendTablistUpdate(tabPlayer)
+            plugin.proxy.allPlayers.forEach {
+                tabService.sendTablistUpdate(it.tabPlayer())
+            }
+        }
     }
 }

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
@@ -2,6 +2,8 @@ package dev.slne.surf.tab.velocity.service
 
 import com.google.auto.service.AutoService
 import com.velocitypowered.api.proxy.player.TabListEntry
+import dev.slne.surf.surfapi.core.api.util.logger
+import dev.slne.surf.tab.api.TabDisplayMode
 import dev.slne.surf.tab.api.TabEntry
 import dev.slne.surf.tab.api.player.TabGameMode
 import dev.slne.surf.tab.api.player.TabPlayer
@@ -35,18 +37,63 @@ class VelocityTablistService : TabService, Services.Fallback {
 
     override fun sendFakeTablist(player: TabPlayer) {
         val velocityPlayer = player.velocityPlayer() ?: return
+        val tabMode = tabConfig.config().displayMode
 
-        plugin.proxy.allPlayers.forEach { online ->
-            val display = tabConfig.config().displayName.formatWithAdventure(online, velocityPlayer)
+        when (tabMode) {
+            TabDisplayMode.PER_PLAYER -> {
+                showEntry(
+                    player, TabEntryImpl(
+                        velocityPlayer.gameProfile.toTabProfile(),
+                        tabConfig.config().displayName.formatWithAdventure(
+                            velocityPlayer,
+                            velocityPlayer
+                        ),
+                        TabGameMode.CREATIVE,
+                        velocityPlayer.ping.toInt(),
+                        luckPermsService.getWeight(velocityPlayer.tabPlayer())
+                    )
+                )
+            }
 
-            val entry = TabEntryImpl(
-                online.gameProfile.toTabProfile(),
-                display,
-                TabGameMode.CREATIVE, online.ping.toInt(),
-                luckPermsService.getWeight(online.tabPlayer())
-            )
+            TabDisplayMode.PER_WORLD -> logger().atWarning()
+                .log("TabDisplayMode PER_WORLD is not supported on Velocity!")
 
-            showEntry(player, entry)
+            TabDisplayMode.PER_SERVER -> {
+                val server = velocityPlayer.currentServer.getOrNull()?.server ?: return
+                server.playersConnected.forEach { online ->
+                    val display =
+                        tabConfig.config().displayName.formatWithAdventure(online, velocityPlayer)
+
+                    val entry = TabEntryImpl(
+                        online.gameProfile.toTabProfile(),
+                        display,
+                        TabGameMode.CREATIVE,
+                        online.ping.toInt(),
+                        luckPermsService.getWeight(online.tabPlayer())
+                    )
+
+                    showEntry(player, entry)
+                }
+            }
+
+            TabDisplayMode.PER_PROXY -> {
+                plugin.proxy.allPlayers.forEach { online ->
+                    val display =
+                        tabConfig.config().displayName.formatWithAdventure(online, velocityPlayer)
+
+                    val entry = TabEntryImpl(
+                        online.gameProfile.toTabProfile(),
+                        display,
+                        TabGameMode.CREATIVE, online.ping.toInt(),
+                        luckPermsService.getWeight(online.tabPlayer())
+                    )
+
+                    showEntry(player, entry)
+                }
+            }
+
+            TabDisplayMode.CLOUD_GLOBAL -> logger().atWarning()
+                .log("TabDisplayMode CLOUD_GLOBAL is not supported on Velocity!")
         }
     }
 

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
@@ -16,6 +16,7 @@ import dev.slne.surf.tab.velocity.util.toTabProfile
 import dev.slne.surf.tab.velocity.util.velocityPlayer
 import net.kyori.adventure.util.Services
 import java.util.*
+import kotlin.jvm.optionals.getOrNull
 
 @AutoService(TabService::class)
 class VelocityTablistService : TabService, Services.Fallback {
@@ -68,13 +69,14 @@ class VelocityTablistService : TabService, Services.Fallback {
         entry: TabEntry
     ) {
         val velocityPlayer = player.velocityPlayer() ?: return
+        val targetPlayer = plugin.proxy.getPlayer(entry.profile.uuid).getOrNull() ?: return
 
         velocityPlayer.tabList.addEntry(
             TabListEntry.builder()
-                .tabList(velocityPlayer.tabList)
-                .profile(velocityPlayer.gameProfile)
+                .tabList(targetPlayer.tabList)
+                .profile(targetPlayer.gameProfile)
                 .displayName(entry.display)
-                .latency(velocityPlayer.ping.toInt())
+                .latency(targetPlayer.ping.toInt())
                 .gameMode(TabGameMode.CREATIVE.index)
                 .listed(true)
                 .listOrder(entry.weight)

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/service/VelocityTablistService.kt
@@ -1,11 +1,7 @@
 package dev.slne.surf.tab.velocity.service
 
-import com.github.retrooper.packetevents.PacketEvents
-import com.github.retrooper.packetevents.protocol.player.UserProfile
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoRemove
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerInfoUpdate
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams
 import com.google.auto.service.AutoService
+import com.velocitypowered.api.proxy.player.TabListEntry
 import dev.slne.surf.tab.api.TabEntry
 import dev.slne.surf.tab.api.player.TabGameMode
 import dev.slne.surf.tab.api.player.TabPlayer
@@ -16,10 +12,8 @@ import dev.slne.surf.tab.velocity.plugin
 import dev.slne.surf.tab.velocity.tabConfig
 import dev.slne.surf.tab.velocity.util.formatWithAdventure
 import dev.slne.surf.tab.velocity.util.tabPlayer
-import dev.slne.surf.tab.velocity.util.toPeGameMode
+import dev.slne.surf.tab.velocity.util.toTabProfile
 import dev.slne.surf.tab.velocity.util.velocityPlayer
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.util.Services
 import java.util.*
 
@@ -35,17 +29,18 @@ class VelocityTablistService : TabService, Services.Fallback {
 
     override fun clearActualTablist(player: TabPlayer) {
         val velocityPlayer = player.velocityPlayer() ?: return
-        velocityPlayer.tabList.entries.forEach { it.isListed = false }
+        velocityPlayer.tabList.entries.forEach { velocityPlayer.tabList.removeEntry(it.profile.id) }
     }
 
     override fun sendFakeTablist(player: TabPlayer) {
         val velocityPlayer = player.velocityPlayer() ?: return
 
         plugin.proxy.allPlayers.forEach { online ->
-            val display = tabConfig.config().displayName.formatWithAdventure(velocityPlayer, online)
+            val display = tabConfig.config().displayName.formatWithAdventure(online, velocityPlayer)
 
             val entry = TabEntryImpl(
-                online.uniqueId, online.username, display,
+                online.gameProfile.toTabProfile(),
+                display,
                 TabGameMode.CREATIVE, online.ping.toInt(),
                 luckPermsService.getWeight(online.tabPlayer())
             )
@@ -73,81 +68,27 @@ class VelocityTablistService : TabService, Services.Fallback {
         entry: TabEntry
     ) {
         val velocityPlayer = player.velocityPlayer() ?: return
-        val addPlayerPacket = WrapperPlayServerPlayerInfoUpdate(
-            EnumSet.of(
-                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_DISPLAY_NAME,
-                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY
-            ),
-            WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                UserProfile(
-                    entry.associatedPlayer, "fake-${entry.associatedPlayer}"
-                ),
-                true,
-                entry.ping,
-                entry.gameMode.toPeGameMode(),
-                entry.display,
-                null,
-                0
-            )
-        )
 
-        val teamName = "${entry.weight}-${entry.associatedName}"
-
-        val teamPacket = WrapperPlayServerTeams(
-            teamName,
-            WrapperPlayServerTeams.TeamMode.CREATE,
-            WrapperPlayServerTeams.ScoreBoardTeamInfo(
-                Component.text(entry.associatedName),
-                null,
-                null,
-                WrapperPlayServerTeams.NameTagVisibility.ALWAYS,
-                WrapperPlayServerTeams.CollisionRule.ALWAYS,
-                NamedTextColor.RED,
-                WrapperPlayServerTeams.OptionData.NONE
-            ),
-            entry.associatedName
+        velocityPlayer.tabList.addEntry(
+            TabListEntry.builder()
+                .tabList(velocityPlayer.tabList)
+                .profile(velocityPlayer.gameProfile)
+                .displayName(entry.display)
+                .latency(velocityPlayer.ping.toInt())
+                .gameMode(TabGameMode.CREATIVE.index)
+                .listed(true)
+                .listOrder(entry.weight)
+                .showHat(true)
+                .build()
         )
-        val teamUpdatePacket = WrapperPlayServerTeams(
-            teamName,
-            WrapperPlayServerTeams.TeamMode.UPDATE,
-            WrapperPlayServerTeams.ScoreBoardTeamInfo(
-                entry.display,
-                null,
-                null,
-                WrapperPlayServerTeams.NameTagVisibility.ALWAYS,
-                WrapperPlayServerTeams.CollisionRule.ALWAYS,
-                NamedTextColor.RED,
-                WrapperPlayServerTeams.OptionData.NONE
-            ),
-            entry.associatedName
-        )
-        val nullInfo: WrapperPlayServerTeams.ScoreBoardTeamInfo? = null
-
-        val teamAddPacket = WrapperPlayServerTeams(
-            teamName,
-            WrapperPlayServerTeams.TeamMode.ADD_ENTITIES,
-            nullInfo,
-            entry.associatedName
-        )
-
-        PacketEvents.getAPI().playerManager.sendPacket(velocityPlayer, addPlayerPacket)
-        PacketEvents.getAPI().playerManager.sendPacket(velocityPlayer, teamPacket)
-        PacketEvents.getAPI().playerManager.sendPacket(velocityPlayer, teamUpdatePacket)
-        PacketEvents.getAPI().playerManager.sendPacket(velocityPlayer, teamAddPacket)
     }
 
     override fun hideEntry(
         player: TabPlayer,
-        entry: TabEntry
+        entry: UUID
     ) {
         val velocityPlayer = player.velocityPlayer() ?: return
-        val removePlayerPacket = WrapperPlayServerPlayerInfoRemove(
-            entry.associatedPlayer
-        )
-
-        PacketEvents.getAPI().playerManager.sendPacket(velocityPlayer, removePlayerPacket)
+        velocityPlayer.tabList.removeEntry(entry)
     }
 
     override fun updateEntry(

--- a/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/util/player-util.kt
+++ b/surf-tab-velocity/src/main/kotlin/dev/slne/surf/tab/velocity/util/player-util.kt
@@ -2,6 +2,10 @@ package dev.slne.surf.tab.velocity.util
 
 import com.github.retrooper.packetevents.protocol.player.GameMode
 import com.velocitypowered.api.proxy.Player
+import com.velocitypowered.api.util.GameProfile
+import dev.slne.surf.surfapi.core.api.util.toObjectSet
+import dev.slne.surf.tab.api.auth.TabGameProfile
+import dev.slne.surf.tab.api.auth.TabProperty
 import dev.slne.surf.tab.api.player.TabGameMode
 import dev.slne.surf.tab.api.player.TabPlayer
 import dev.slne.surf.tab.core.factory.tabPlayerFactory
@@ -17,3 +21,13 @@ fun TabGameMode.toPeGameMode() = when (this) {
     TabGameMode.ADVENTURE -> GameMode.ADVENTURE
     TabGameMode.SPECTATOR -> GameMode.SPECTATOR
 }
+
+fun GameProfile.toTabProfile() = TabGameProfile(
+    this.id,
+    this.name,
+    this.properties.map { TabProperty(it.name, it.value, it.signature) }.toObjectSet()
+)
+
+fun TabGameProfile.toGameProfile() = GameProfile(this.uuid, this.name, this.properties.map {
+    GameProfile.Property(it.name, it.value, it.signature)
+})


### PR DESCRIPTION
This pull request refactors how player profiles are represented and managed in the tablist system, introduces a new `TabGameProfile` abstraction, and updates the Velocity implementation to use Velocity's native tablist API instead of low-level packet manipulation. It also improves configuration handling for display modes and clarifies which modes are supported on Velocity.

**API and Model Refactoring:**

* Replaced `associatedName` and `associatedPlayer` in `TabEntry` with a new `profile: TabGameProfile` property, and updated all usages accordingly. This provides a more structured and extensible way to represent player identity and properties. [[1]](diffhunk://#diff-4b197ab35e337f8640a317f3b85a617fd0ac03394b75ee8bb03fc3bb25822382R3-R8) [[2]](diffhunk://#diff-6632258500257292d916491b3f73eb4329faabf2efbaea3ce3c0ee66f2186d18R4-R9)
* Introduced `TabGameProfile` and `TabProperty` data classes to encapsulate player UUID, name, and properties. [[1]](diffhunk://#diff-dc48277368ffde6262d906db6d28640f6bf3f9ee97aca5fb4165d794d68be604R1-R10) [[2]](diffhunk://#diff-eb1a178ac8f26091a5f45c89bf8a7396c4192aa24b9b30d92ccb49f7fb482823R1-R7)
* Updated `TabGameMode` enum to include an `index` field to match protocol expectations.

**Service and Interface Changes:**

* Changed `TabService.hideEntry` and `hideEntries` methods to work with player UUIDs instead of full `TabEntry` objects, simplifying entry removal.

**Velocity Platform Implementation:**

* Refactored `VelocityTablistService` to use Velocity's `TabListEntry` API for adding and removing tab entries, removing all direct packet manipulation and team packet logic. [[1]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL3-R6) [[2]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL19-R21) [[3]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL38-R86) [[4]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dR95-R99) [[5]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL76-R140)
* Added utility functions for converting between Velocity `GameProfile` and the new `TabGameProfile`. [[1]](diffhunk://#diff-97c49a047aa6edf817275e407c2425bbf369d9aa48ac13c74ff8606d2c73569eR5-R8) [[2]](diffhunk://#diff-97c49a047aa6edf817275e407c2425bbf369d9aa48ac13c74ff8606d2c73569eR24-R33)
* Updated `ConnectionListener` to asynchronously update the tablist for all players after a short delay on connect, improving reliability.

**Configuration Improvements:**

* Changed `TabConfig.displayMode` from a `String` to a strongly-typed `TabDisplayMode` enum and enforced that only supported modes are used on Velocity, with warnings and automatic fallback to `PER_PROXY` if necessary. [[1]](diffhunk://#diff-d32f835b6335dc2d9ba059948135532410eada9ef42c29146ab631e618f49123R4) [[2]](diffhunk://#diff-d32f835b6335dc2d9ba059948135532410eada9ef42c29146ab631e618f49123L12-R13) [[3]](diffhunk://#diff-bdd3d01ff0dc80c2b161f03f85ee121a702c1fb225652fb40be7e0011fc65a8aR5-R6) [[4]](diffhunk://#diff-bdd3d01ff0dc80c2b161f03f85ee121a702c1fb225652fb40be7e0011fc65a8aR21-R26)

---

**API and Model Refactoring**
- Replaced `associatedName`/`associatedPlayer` in `TabEntry` with a new `profile: TabGameProfile` property, and updated all usages, including in `TabEntryImpl`. [[1]](diffhunk://#diff-4b197ab35e337f8640a317f3b85a617fd0ac03394b75ee8bb03fc3bb25822382R3-R8) [[2]](diffhunk://#diff-6632258500257292d916491b3f73eb4329faabf2efbaea3ce3c0ee66f2186d18R4-R9)
- Introduced `TabGameProfile` and `TabProperty` data classes for structured player identity and properties. [[1]](diffhunk://#diff-dc48277368ffde6262d906db6d28640f6bf3f9ee97aca5fb4165d794d68be604R1-R10) [[2]](diffhunk://#diff-eb1a178ac8f26091a5f45c89bf8a7396c4192aa24b9b30d92ccb49f7fb482823R1-R7)
- Added `index` field to `TabGameMode` enum for protocol compatibility.

**Service and Interface Changes**
- Changed `TabService.hideEntry` and `hideEntries` to use UUIDs instead of `TabEntry` objects, simplifying tab entry removal.

**Velocity Platform Implementation**
- Switched from packet-level tablist management to Velocity's `TabListEntry` API, removing all manual packet and team handling. [[1]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL3-R6) [[2]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL19-R21) [[3]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL38-R86) [[4]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dR95-R99) [[5]](diffhunk://#diff-272bb0062269b82a577b1b376a921723ec0f396bab562354b7753aaefbb53d5dL76-R140)
- Added conversion utilities between Velocity `GameProfile` and `TabGameProfile`. [[1]](diffhunk://#diff-97c49a047aa6edf817275e407c2425bbf369d9aa48ac13c74ff8606d2c73569eR5-R8) [[2]](diffhunk://#diff-97c49a047aa6edf817275e407c2425bbf369d9aa48ac13c74ff8606d2c73569eR24-R33)
- Updated connection listener to asynchronously update all players' tablists after connect events.

**Configuration Improvements**
- Changed `TabConfig.displayMode` to use the `TabDisplayMode` enum, and added logic to warn and fallback to `PER_PROXY` for unsupported modes on Velocity. [[1]](diffhunk://#diff-d32f835b6335dc2d9ba059948135532410eada9ef42c29146ab631e618f49123R4) [[2]](diffhunk://#diff-d32f835b6335dc2d9ba059948135532410eada9ef42c29146ab631e618f49123L12-R13) [[3]](diffhunk://#diff-bdd3d01ff0dc80c2b161f03f85ee121a702c1fb225652fb40be7e0011fc65a8aR5-R6) [[4]](diffhunk://#diff-bdd3d01ff0dc80c2b161f03f85ee121a702c1fb225652fb40be7e0011fc65a8aR21-R26)