### PR TITLE
Temporary vanish api hook fix

### DIFF
--- a/surf-tab-paper/build.gradle.kts
+++ b/surf-tab-paper/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     compileOnly(libs.mini.placeholders.kotlin)
     compileOnly(libs.luckperms.api)
     api(project(":surf-tab-api"))
-    compileOnly("dev.slne.surf.vanish:surf-vanish-api-redis:1.21.11-1.0.9-SNAPSHOT")
+    implementation("dev.slne.surf.vanish:surf-vanish-api-redis:1.21.11-1.0.9-SNAPSHOT")
     compileOnly("dev.slne.surf.vanish:surf-vanish-api:1.21.11-1.0.9-SNAPSHOT")
     compileOnly("dev.slne.surf.playtime:surf-playtime-api:1.21.11-1.1.0-SNAPSHOT")
 }


### PR DESCRIPTION
This pull request makes a small but important change to the dependency configuration in `surf-tab-paper/build.gradle.kts`. The dependency on `surf-vanish-api-redis` is now included as an `implementation` dependency instead of `compileOnly`, ensuring it is available at runtime rather than just at compile time.

- Changed `surf-vanish-api-redis` dependency from `compileOnly` to `implementation` in `surf-tab-paper/build.gradle.kts`, making it available at runtime.