### PR TITLE
Fix/weight

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.2.4
+version=1.2.5

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/LuckPermsHook.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/LuckPermsHook.kt
@@ -1,30 +1,20 @@
 package dev.slne.surf.tab.core.client.hook
 
+import dev.slne.surf.api.core.luckperms.LuckPermsAccess
 import dev.slne.surf.tab.core.client.platform.TabPlatform
 import dev.slne.surf.tab.core.client.service.tablistService
-import net.luckperms.api.LuckPermsProvider
 import net.luckperms.api.model.user.User
 import java.util.*
 
 object LuckPermsHook {
-    val luckPerms by lazy {
-        LuckPermsProvider.get()
+
+    fun getWeight(player: UUID): Int {
+        val user = LuckPermsAccess.getUser(player) ?: return 0
+
+        return user.getInheritedGroups(user.queryOptions)
+            .maxOfOrNull { it.weight.orElse(0) }
+            ?: 0
     }
-
-    fun getPrefix(player: UUID) =
-        getUser(player)?.primaryGroup?.let {
-            luckPerms.groupManager.getGroup(it)?.cachedData?.metaData?.prefix ?: ""
-        } ?: ""
-
-    fun getSuffix(player: UUID) =
-        getUser(player)?.primaryGroup?.let {
-            luckPerms.groupManager.getGroup(it)?.cachedData?.metaData?.suffix ?: ""
-        } ?: ""
-
-    fun getWeight(player: UUID) =
-        getUser(player)?.primaryGroup?.let {
-            luckPerms.groupManager.getGroup(it)?.weight?.orElse(0) ?: 0
-        } ?: 0
 
     fun updatePlayerInTablist(user: User) {
         TabPlatform.launch {
@@ -33,6 +23,4 @@ object LuckPermsHook {
             }
         }
     }
-
-    private fun getUser(uuid: UUID) = luckPerms.userManager.getUser(uuid)
 }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/platform/TabPlayer.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/platform/TabPlayer.kt
@@ -22,6 +22,11 @@ interface TabPlayer {
     fun baseName(): Component
 
     /**
+     * Reads [baseName] on the owning entity context when the platform requires it.
+     */
+    suspend fun baseNameSnapshot(): Component
+
+    /**
      * Shows [name] as this player's tablist entry, sorted by [order] where a higher order comes
      * first.
      */

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdater.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdater.kt
@@ -1,0 +1,91 @@
+package dev.slne.surf.tab.core.client.service
+
+import dev.slne.surf.api.core.messages.adventure.buildText
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import net.kyori.adventure.text.Component
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+enum class TabEntryPart {
+    ORDER,
+    VANISH,
+    CLAN,
+    LIVE,
+    AFK
+}
+
+/**
+ * Builds a player's tablist entry in two stages.
+ *
+ * The base entry is shown before the suspendable clan enrichment starts. Failures in one optional
+ * part fall back only that part, while cancellation still propagates to the update coalescer.
+ */
+class TabEntryUpdater<T>(
+    private val baseName: suspend (T) -> Component,
+    private val order: (T) -> Int,
+    private val vanishTag: (T) -> Component,
+    private val clanTag: suspend (T) -> Component?,
+    private val liveTag: (T) -> Component,
+    private val afkTag: (T) -> Component,
+    private val show: suspend (T, Component, Int) -> Unit,
+    private val clanTimeout: Duration = 2.seconds,
+    private val onPartFailure: (TabEntryPart, T, Throwable) -> Unit
+) {
+
+    suspend fun update(target: T) {
+        val base = baseName(target)
+        val order = resolve(TabEntryPart.ORDER, target, 0) { order(target) }
+        val vanish = resolve(TabEntryPart.VANISH, target, Component.empty()) { vanishTag(target) }
+        val live = resolve(TabEntryPart.LIVE, target, Component.empty()) { liveTag(target) }
+        val afk = resolve(TabEntryPart.AFK, target, Component.empty()) { afkTag(target) }
+
+        show(target, render(base, vanish, null, live, afk), order)
+
+        val clan = resolveClan(target) ?: return
+        show(target, render(base, vanish, clan, live, afk), order)
+    }
+
+    private suspend fun resolveClan(target: T): Component? = try {
+        withTimeout(clanTimeout) {
+            clanTag(target)
+        }
+    } catch (timeout: TimeoutCancellationException) {
+        onPartFailure(TabEntryPart.CLAN, target, timeout)
+        null
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (throwable: Throwable) {
+        onPartFailure(TabEntryPart.CLAN, target, throwable)
+        null
+    }
+
+    private fun render(
+        base: Component,
+        vanish: Component,
+        clan: Component?,
+        live: Component,
+        afk: Component
+    ) = buildText {
+        append(vanish)
+        append(base)
+        clan?.let { append(it) }
+        append(live)
+        append(afk)
+    }
+
+    private suspend fun <R> resolve(
+        part: TabEntryPart,
+        target: T,
+        fallback: R,
+        value: suspend () -> R
+    ): R = try {
+        value()
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (throwable: Throwable) {
+        onPartFailure(part, target, throwable)
+        fallback
+    }
+}

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistService.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistService.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.tab.core.client.service
 
 import dev.slne.surf.api.core.messages.adventure.buildText
 import dev.slne.surf.api.core.minimessage.miniMessage
+import dev.slne.surf.api.core.util.logger
 import dev.slne.surf.core.api.common.server.SurfServer
 import dev.slne.surf.tab.core.client.config.tablistConfig
 import dev.slne.surf.tab.core.client.hook.ClanHook
@@ -17,8 +18,14 @@ import net.kyori.adventure.text.Component
 import java.time.ZonedDateTime
 import java.util.*
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.seconds
 
 val tablistService = TablistService()
+
+private val log = logger()
+
+private val tabEntryUpdateTimeout = 5.seconds
+private val clanLookupTimeout = 2.seconds
 
 private val afkTag = buildText {
     appendSpace()
@@ -36,9 +43,29 @@ private val vanishTag = buildText {
 
 class TablistService {
 
-    private val updates = UpdateCoalescer<TabPlayer>(
+    private val entryUpdater = TabEntryUpdater<TabPlayer>(
+        baseName = { player -> player.baseNameSnapshot() },
+        order = { player -> LuckPermsHook.getWeight(player.uuid) },
+        vanishTag = { player -> getVanishTag(player.uuid) },
+        clanTag = { player -> getClanTag(player.uuid) },
+        liveTag = { player -> getLiveTag(player.uuid) },
+        afkTag = { player -> getAfkTag(player.uuid) },
+        show = { player, name, order -> player.showTabEntry(name, order) },
+        clanTimeout = clanLookupTimeout,
+        onPartFailure = { part, player, failure ->
+            log.atWarning()
+                .withCause(failure)
+                .log("Failed to resolve tablist part %s for player %s", part, player.uuid)
+        }
+    )
+
+    private val updates = UpdateCoalescer(
         runUpdates = { block -> TabPlatform.launch { block() } },
-        update = { player -> formatPlayer(player) }
+        updateTimeout = tabEntryUpdateTimeout,
+        onTimeout = { playerUuid, _ ->
+            log.atWarning().log("Tablist update for player %s timed out", playerUuid)
+        },
+        update = entryUpdater::update
     )
 
     /**
@@ -134,18 +161,6 @@ class TablistService {
         )
     }
 
-    private suspend fun formatPlayer(player: TabPlayer) {
-        player.showTabEntry(formatDisplayName(player), LuckPermsHook.getWeight(player.uuid))
-    }
-
-    private suspend fun formatDisplayName(player: TabPlayer) = buildText {
-        append(getVanishTag(player.uuid))
-        append(player.baseName())
-        append(getClanTag(player.uuid))
-        append(getLiveTag(player.uuid))
-        append(getAfkTag(player.uuid))
-    }
-
     private fun getAfkTag(playerUuid: UUID) = if (isAfk(playerUuid)) {
         afkTag
     } else {
@@ -159,18 +174,15 @@ class TablistService {
             Component.empty()
         }
 
-    private suspend fun getClanTag(playerUuid: UUID) = if (TabPlatform.clanAvailable) {
-        val tag = ClanHook.getClanTag(playerUuid)
-        if (tag != null) {
-            buildText {
-                appendSpace()
-                append(tag)
-            }
-        } else {
-            Component.empty()
+    private suspend fun getClanTag(playerUuid: UUID): Component? {
+        if (!TabPlatform.clanAvailable) return null
+
+        val tag = ClanHook.getClanTag(playerUuid) ?: return null
+
+        return buildText {
+            appendSpace()
+            append(tag)
         }
-    } else {
-        Component.empty()
     }
 
     private fun getVanishTag(playerUuid: UUID) = if (isVanished(playerUuid)) {

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
@@ -1,8 +1,10 @@
 package dev.slne.surf.tab.core.client.service
 
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Coalesces update requests so that at most one update is running for a key at any time.
@@ -32,10 +34,14 @@ import kotlin.coroutines.cancellation.CancellationException
  * scheduling behavior of [runUpdates].
  *
  * @param runUpdates schedules an update loop on the scope or dispatcher on which updates must run
+ * @param updateTimeout the maximum time one update pass may occupy its key
+ * @param onTimeout observes a pass that exceeded [updateTimeout]
  * @param update performs a single update for the supplied target
  */
 internal class UpdateCoalescer<T>(
     private val runUpdates: (suspend () -> Unit) -> Unit,
+    private val updateTimeout: Duration = 5.seconds,
+    private val onTimeout: (UUID, T) -> Unit = { _, _ -> },
     private val update: suspend (T) -> Unit
 ) {
 
@@ -125,9 +131,18 @@ internal class UpdateCoalescer<T>(
 
         while (true) {
             try {
-                update(current.target)
+                val completed = withTimeoutOrNull(updateTimeout) {
+                    update(current.target)
+                    true
+                }
+
+                if (completed == null) {
+                    runCatching {
+                        onTimeout(key, current.target)
+                    }
+                }
             } catch (throwable: Throwable) {
-                giveUp(key, current, throwable)
+                giveUp(key, current)
                 throw throwable
             }
 
@@ -147,21 +162,20 @@ internal class UpdateCoalescer<T>(
      * If a newer request arrived while the failed pass was running, that request belongs to neither
      * the failed operation nor its target and is therefore submitted again as a fresh update loop.
      *
-     * Cancellation is treated differently: when the coroutine is being cancelled, no replacement
-     * loop is started because doing so would effectively escape the cancellation of the current
-     * update scope.
-     *
      * @param key the key whose update failed
      * @param current the request whose update threw
-     * @param failure the exception thrown by the update
      */
-    private fun giveUp(key: UUID, current: Requested<T>, failure: Throwable) {
-        val requested = inFlight.remove(key)
+    private fun giveUp(key: UUID, current: Requested<T>) {
+        while (true) {
+            val requested = inFlight[key] ?: return
 
-        if (requested == null || requested === current) return
-        if (failure is CancellationException) return
+            if (requested === current) {
+                if (inFlight.remove(key, current)) return
+                continue
+            }
 
-        request(key, requested.target)
+            return handOver(key, requested)
+        }
     }
 }
 

--- a/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdaterTest.kt
+++ b/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdaterTest.kt
@@ -1,0 +1,149 @@
+package dev.slne.surf.tab.core.client.service
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import net.kyori.adventure.text.Component
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class TabEntryUpdaterTest {
+
+    @Test
+    fun `each nonessential part can fail without discarding the other parts`() = runBlocking {
+        val cases = listOf(
+            FailureCase(TabEntryPart.ORDER, "VnameCLA", 0, 2),
+            FailureCase(TabEntryPart.VANISH, "nameCLA", 7, 2),
+            FailureCase(TabEntryPart.CLAN, "VnameLA", 7, 1),
+            FailureCase(TabEntryPart.LIVE, "VnameCA", 7, 2),
+            FailureCase(TabEntryPart.AFK, "VnameCL", 7, 2)
+        )
+
+        for (case in cases) {
+            val shown = ArrayList<Pair<String, Int>>()
+            val failures = ArrayList<TabEntryPart>()
+            val updater = TabEntryUpdater<String>(
+                baseName = { Component.text(it) },
+                order = { case.value(TabEntryPart.ORDER, 7) },
+                vanishTag = { case.value(TabEntryPart.VANISH, Component.text("V")) },
+                clanTag = { case.value(TabEntryPart.CLAN, Component.text("C")) },
+                liveTag = { case.value(TabEntryPart.LIVE, Component.text("L")) },
+                afkTag = { case.value(TabEntryPart.AFK, Component.text("A")) },
+                show = { _, name, order -> shown += name.plain() to order },
+                onPartFailure = { part, _, _ -> failures += part }
+            )
+
+            updater.update("name")
+
+            assertEquals(case.expectedWrites, shown.size, "writes after ${case.part} failed")
+            assertEquals(
+                case.expectedName to case.expectedOrder,
+                shown.last(),
+                "entry after ${case.part} failed"
+            )
+            assertEquals(listOf(case.part), failures)
+        }
+    }
+
+    @Test
+    fun `a stuck clan lookup leaves a base entry and a later refresh still succeeds`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val baseShown = CompletableDeferred<Unit>()
+        val clanStarted = CompletableDeferred<Unit>()
+        val clanCancelled = CompletableDeferred<Unit>()
+        val refreshed = CompletableDeferred<Unit>()
+        val shown = CopyOnWriteArrayList<String>()
+        var clanLookups = 0
+
+        try {
+            val updater = TabEntryUpdater<String>(
+                baseName = { Component.text(it) },
+                order = { 7 },
+                vanishTag = { Component.empty() },
+                clanTag = {
+                    if (clanLookups++ == 0) {
+                        clanStarted.complete(Unit)
+                        try {
+                            awaitCancellation()
+                        } finally {
+                            clanCancelled.complete(Unit)
+                        }
+                    } else {
+                        Component.text("C")
+                    }
+                },
+                liveTag = { Component.empty() },
+                afkTag = { Component.empty() },
+                show = { _, name, _ ->
+                    shown += name.plain()
+                    if (shown.size == 1) baseShown.complete(Unit)
+                    if (name.plain() == "nameC") refreshed.complete(Unit)
+                },
+                onPartFailure = { _, _, _ -> }
+            )
+            val coalescer = UpdateCoalescer<String>(
+                runUpdates = { block -> scope.launch { block() } },
+                updateTimeout = 50.milliseconds,
+                update = updater::update
+            )
+            val key = UUID.randomUUID()
+
+            coalescer.request(key, "name")
+            withTimeout(1.seconds) { baseShown.await() }
+            withTimeout(1.seconds) { clanStarted.await() }
+            assertEquals("name", shown.single(), "the base entry must precede clan enrichment")
+
+            withTimeout(1.seconds) { clanCancelled.await() }
+            coalescer.request(key, "name")
+            withTimeout(1.seconds) { refreshed.await() }
+
+            assertEquals("nameC", shown.last())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a clan timeout keeps the already applied base entry`() = runBlocking {
+        val shown = ArrayList<String>()
+        val failures = ArrayList<TabEntryPart>()
+        val updater = TabEntryUpdater<String>(
+            baseName = { Component.text(it) },
+            order = { 7 },
+            vanishTag = { Component.text("V") },
+            clanTag = { awaitCancellation() },
+            liveTag = { Component.text("L") },
+            afkTag = { Component.text("A") },
+            show = { _, name, _ -> shown += name.plain() },
+            clanTimeout = 50.milliseconds,
+            onPartFailure = { part, _, _ -> failures += part }
+        )
+
+        withTimeout(1.seconds) { updater.update("name") }
+
+        assertEquals(listOf("VnameLA"), shown)
+        assertEquals(listOf(TabEntryPart.CLAN), failures)
+    }
+
+    private data class FailureCase(
+        val part: TabEntryPart,
+        val expectedName: String,
+        val expectedOrder: Int,
+        val expectedWrites: Int
+    ) {
+        fun <T> value(requestedPart: TabEntryPart, value: T): T {
+            if (part == requestedPart) error("$part failed")
+            return value
+        }
+    }
+}

--- a/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
+++ b/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
@@ -1,12 +1,18 @@
 package dev.slne.surf.tab.core.client.service
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -15,6 +21,8 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class UpdateCoalescerTest {
 
@@ -141,6 +149,136 @@ class UpdateCoalescerTest {
         assertThrows(IllegalStateException::class.java) { coalescer.request(key, "original") }
 
         assertEquals(listOf("original", "reconnected"), updated)
+    }
+
+    @Test
+    fun `a newer request is still applied when the running update is cancelled`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstStarted = CompletableDeferred<Unit>()
+        val newestApplied = CompletableDeferred<String>()
+        lateinit var firstJob: Job
+        var launches = 0
+
+        try {
+            val coalescer = UpdateCoalescer<String>(
+                runUpdates = { block ->
+                    scope.launch { block() }.also { job ->
+                        if (launches++ == 0) firstJob = job
+                    }
+                },
+                update = { target ->
+                    if (target == "cancelled") {
+                        firstStarted.complete(Unit)
+                        awaitCancellation()
+                    } else {
+                        delay(1.milliseconds)
+                        newestApplied.complete(target)
+                    }
+                }
+            )
+
+            coalescer.request(key, "cancelled")
+            firstStarted.await()
+            coalescer.request(key, "newest")
+            firstJob.cancelAndJoin()
+
+            assertEquals("newest", withTimeout(1.seconds) { newestApplied.await() })
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `an external timeout cancellation is not mistaken for the update timeout`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstStarted = CompletableDeferred<Unit>()
+        val newestApplied = CompletableDeferred<String>()
+        lateinit var firstJob: Job
+        var launches = 0
+        val externalTimeout = runCatching {
+            withTimeout(1.milliseconds) { awaitCancellation() }
+        }.exceptionOrNull() as TimeoutCancellationException
+
+        try {
+            val coalescer = UpdateCoalescer<String>(
+                runUpdates = { block ->
+                    scope.launch { block() }.also { job ->
+                        if (launches++ == 0) firstJob = job
+                    }
+                },
+                update = { target ->
+                    if (target == "cancelled") {
+                        firstStarted.complete(Unit)
+                        awaitCancellation()
+                    } else {
+                        delay(1.milliseconds)
+                        newestApplied.complete(target)
+                    }
+                }
+            )
+
+            coalescer.request(key, "cancelled")
+            firstStarted.await()
+            coalescer.request(key, "newest")
+            firstJob.cancel(externalTimeout)
+            firstJob.join()
+
+            assertEquals("newest", withTimeout(1.seconds) { newestApplied.await() })
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a timed out update does not wedge the key and the newest request wins`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstStarted = CompletableDeferred<Unit>()
+        val newestApplied = CompletableDeferred<String>()
+        val timedOut = CompletableDeferred<String>()
+
+        try {
+            val coalescer = UpdateCoalescer<String>(
+                runUpdates = { block -> scope.launch { block() } },
+                update = { target ->
+                    if (target == "stuck") {
+                        firstStarted.complete(Unit)
+                        awaitCancellation()
+                    } else {
+                        newestApplied.complete(target)
+                    }
+                },
+                updateTimeout = 50.milliseconds,
+                onTimeout = { _, target -> timedOut.complete(target) }
+            )
+
+            coalescer.request(key, "stuck")
+            firstStarted.await()
+            coalescer.request(key, "newest")
+
+            assertEquals("stuck", withTimeout(1.seconds) { timedOut.await() })
+            assertEquals("newest", withTimeout(1.seconds) { newestApplied.await() })
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a failing timeout observer does not wedge the key`() {
+        var updates = 0
+        val coalescer = UpdateCoalescer<String>(
+            runUpdates = ::runHere,
+            updateTimeout = 10.milliseconds,
+            onTimeout = { _, _ -> error("observer failed") },
+            update = {
+                updates++
+                if (updates == 1) awaitCancellation()
+            }
+        )
+
+        coalescer.request(key, "first")
+        coalescer.request(key, "second")
+
+        assertEquals(2, updates)
     }
 
     @Test

--- a/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/hook/luck-perms-listeners.kt
+++ b/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/hook/luck-perms-listeners.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.tab.minestom.hook
 
+import dev.slne.surf.api.core.luckperms.LuckPermsAccess
 import dev.slne.surf.tab.core.client.hook.LuckPermsHook
 import net.luckperms.api.event.node.NodeAddEvent
 import net.luckperms.api.event.node.NodeRemoveEvent
@@ -7,7 +8,7 @@ import net.luckperms.api.event.user.UserDataRecalculateEvent
 import net.luckperms.api.model.user.User
 
 fun registerLuckPermsListeners() {
-    val eventBus = LuckPermsHook.luckPerms.eventBus
+    val eventBus = LuckPermsAccess.luckperms.eventBus
 
     eventBus.subscribe(NodeAddEvent::class.java) { event ->
         val user = event.target as? User ?: return@subscribe

--- a/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/platform/MinestomTabPlayer.kt
+++ b/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/platform/MinestomTabPlayer.kt
@@ -16,6 +16,8 @@ class MinestomTabPlayer(private val player: Player) : TabPlayer {
     override fun baseName(): Component =
         miniMessage.deserialize("${LuckPermsAccess.getUser(player.uuid)?.prefix ?: ""}${player.username}")
 
+    override suspend fun baseNameSnapshot(): Component = player.withEntity { baseName() }
+
     override suspend fun showTabEntry(name: Component, order: Int) {
         player.withEntity {
             it.displayName = name

--- a/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/hook/luck-perms-listeners.kt
+++ b/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/hook/luck-perms-listeners.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.tab.paper.hook
 
+import dev.slne.surf.api.core.luckperms.LuckPermsAccess
 import dev.slne.surf.tab.core.client.hook.LuckPermsHook
 import dev.slne.surf.tab.paper.plugin
 import net.luckperms.api.event.node.NodeAddEvent
@@ -8,7 +9,7 @@ import net.luckperms.api.event.user.UserDataRecalculateEvent
 import net.luckperms.api.model.user.User
 
 fun registerLuckPermsListeners() {
-    val eventBus = LuckPermsHook.luckPerms.eventBus
+    val eventBus = LuckPermsAccess.luckperms.eventBus
 
     eventBus.subscribe(plugin, NodeAddEvent::class.java) { event ->
         val user = event.target as? User ?: return@subscribe

--- a/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/platform/PaperTabPlayer.kt
+++ b/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/platform/PaperTabPlayer.kt
@@ -13,6 +13,9 @@ class PaperTabPlayer(private val player: Player) : TabPlayer {
 
     override fun baseName(): Component = player.displayName()
 
+    override suspend fun baseNameSnapshot(): Component =
+        withContext(plugin.entityDispatcher(player)) { baseName() }
+
     override suspend fun showTabEntry(name: Component, order: Int) {
         withContext(plugin.entityDispatcher(player)) {
             player.playerListName(name)


### PR DESCRIPTION
This pull request introduces a robust, two-stage system for building and updating player tablist entries, with improved error handling and timeouts for asynchronous parts such as clan lookups. It refactors the tablist update logic to be more modular and resilient, adds granular failure handling for each tab entry part, and improves test coverage for these scenarios. The update coalescing mechanism is also enhanced to support per-update timeouts.

**Tablist entry update refactor and resilience improvements:**

* Introduced the `TabEntryUpdater` class to build tablist entries in two stages, allowing nonessential parts (like clan tags) to fail independently without discarding the whole entry. Each part (order, vanish, clan, live, afk) now has separate error handling, and clan lookups have a configurable timeout. (`surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdater.kt`)
* Refactored `TablistService` to use `TabEntryUpdater` for updating player entries, removed the old monolithic `formatPlayer`/`formatDisplayName` logic, and added logging for part failures and update timeouts. (`surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistService.kt`) [[1]](diffhunk://#diff-3ab1740cf7e0c3b41143d6bb31884d4da9318c72b03488ac1be358f5b8a81aa9L39-R68) [[2]](diffhunk://#diff-3ab1740cf7e0c3b41143d6bb31884d4da9318c72b03488ac1be358f5b8a81aa9L137-L148) [[3]](diffhunk://#diff-3ab1740cf7e0c3b41143d6bb31884d4da9318c72b03488ac1be358f5b8a81aa9L162-L173)

**Update coalescing and timeout handling:**

* Enhanced `UpdateCoalescer` to support per-update timeouts and a callback for handling updates that exceed the timeout. The internal error handling was also revised to ensure correct re-submission of pending updates. (`surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt`) [[1]](diffhunk://#diff-844967fe14875d01e969b952afa806d1e4fd8d34d3b7de7528875c8dcf93710fR37-R44) [[2]](diffhunk://#diff-844967fe14875d01e969b952afa806d1e4fd8d34d3b7de7528875c8dcf93710fR134-R145) [[3]](diffhunk://#diff-844967fe14875d01e969b952afa806d1e4fd8d34d3b7de7528875c8dcf93710fL150-R178)

**API and hook adjustments:**

* Simplified `LuckPermsHook` to use a new `LuckPermsAccess` API, streamlining group weight retrieval, and removed unused prefix/suffix methods. (`surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/LuckPermsHook.kt`, [[1]](diffhunk://#diff-258bffaaef3a75f8ffd0e7d1382d0bed882245dac92fa53a6688791e72a83d7cR3-R17) [[2]](diffhunk://#diff-258bffaaef3a75f8ffd0e7d1382d0bed882245dac92fa53a6688791e72a83d7cL36-L37)
* Added `baseNameSnapshot` to the `TabPlayer` interface to support suspendable base name resolution, accommodating platform requirements. (`surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/platform/TabPlayer.kt`)

**Test coverage improvements:**

* Added comprehensive unit tests for `TabEntryUpdater`, covering independent part failures, clan lookup timeouts, and recovery from stuck lookups. (`surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdaterTest.kt`)
* Updated `UpdateCoalescerTest` to cover new timeout and cancellation scenarios. (`surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt`) [[1]](diffhunk://#diff-0e6c4df99bffbdde7adc7db71cf52565582459871c623866b198ef86f6eea8c2R4-R15) [[2]](diffhunk://#diff-0e6c4df99bffbdde7adc7db71cf52565582459871c623866b198ef86f6eea8c2R24-R25)