### PR TITLE
🐛 fix(tablist): convert TablistService to an object to avoid zero timeouts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.2.5
+version=1.2.6

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/command/tablist-reload.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/command/tablist-reload.kt
@@ -3,7 +3,7 @@ package dev.slne.surf.tab.core.client.command
 import dev.slne.surf.api.core.messages.adventure.sendText
 import dev.slne.surf.tab.core.client.config.tablistConfiguration
 import dev.slne.surf.tab.core.client.platform.TabPlatform
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import net.kyori.adventure.audience.Audience
 
 /**
@@ -13,7 +13,7 @@ fun reloadTablist() {
     tablistConfiguration.reload()
 
     TabPlatform.launch {
-        tablistService.refreshAll()
+        TablistService.refreshAll()
     }
 }
 

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/ClanHook.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/ClanHook.kt
@@ -7,7 +7,7 @@ import dev.slne.clan.api.clan.listener.ClanDeletedListener
 import dev.slne.clan.api.clan.listener.ClanUpdateMemberListener
 import dev.slne.clan.api.clan.listener.ClanUpdatedListener
 import dev.slne.surf.tab.core.client.platform.TabPlatform
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import net.kyori.adventure.text.Component
 import java.util.*
 
@@ -26,7 +26,7 @@ object ClanHook {
         TabPlatform.launch {
             for (member in clan.members) {
                 val player = TabPlatform.player(member.uuid) ?: continue
-                tablistService.requestFormat(player)
+                TablistService.requestFormat(player)
             }
         }
     }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/ContentCreatorHook.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/ContentCreatorHook.kt
@@ -5,7 +5,7 @@ import dev.slne.surf.content.creator.api.ContentCreatorPlatform
 import dev.slne.surf.content.creator.api.listener.StateChangeListener
 import dev.slne.surf.content.creator.api.platform.PlatformState
 import dev.slne.surf.tab.core.client.platform.TabPlatform
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import net.kyori.adventure.text.Component
 import java.util.*
 
@@ -22,7 +22,7 @@ object ContentCreatorHook {
             ) {
                 TabPlatform.launch {
                     TabPlatform.player(playerUuid)?.let {
-                        tablistService.requestFormat(it)
+                        TablistService.requestFormat(it)
                     }
                 }
             }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/LuckPermsHook.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/hook/LuckPermsHook.kt
@@ -2,7 +2,7 @@ package dev.slne.surf.tab.core.client.hook
 
 import dev.slne.surf.api.core.luckperms.LuckPermsAccess
 import dev.slne.surf.tab.core.client.platform.TabPlatform
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import net.luckperms.api.model.user.User
 import java.util.*
 
@@ -19,7 +19,7 @@ object LuckPermsHook {
     fun updatePlayerInTablist(user: User) {
         TabPlatform.launch {
             TabPlatform.player(user.uniqueId)?.let {
-                tablistService.requestFormat(it)
+                TablistService.requestFormat(it)
             }
         }
     }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/redis/TabRedisEventListener.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/redis/TabRedisEventListener.kt
@@ -3,13 +3,13 @@ package dev.slne.surf.tab.core.client.redis
 import dev.slne.surf.redis.event.OnRedisEvent
 import dev.slne.surf.tab.api.redis.TabEntryUpdateRedisEvent
 import dev.slne.surf.tab.core.client.platform.TabPlatform
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 
 object TabRedisEventListener {
     @OnRedisEvent
     fun onUpdate(event: TabEntryUpdateRedisEvent) {
         TabPlatform.player(event.toUpdateUuid)?.let {
-            tablistService.requestFormat(it)
+            TablistService.requestFormat(it)
         }
     }
 }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdater.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TabEntryUpdater.kt
@@ -34,6 +34,12 @@ class TabEntryUpdater<T>(
     private val onPartFailure: (TabEntryPart, T, Throwable) -> Unit
 ) {
 
+    init {
+        require(clanTimeout.isPositive()) {
+            "clanTimeout must be positive but was $clanTimeout"
+        }
+    }
+
     suspend fun update(target: T) {
         val base = baseName(target)
         val order = resolve(TabEntryPart.ORDER, target, 0) { order(target) }

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistScheduler.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistScheduler.kt
@@ -47,13 +47,13 @@ object TablistScheduler {
     private suspend fun run() {
         while (currentCoroutineContext().isActive) {
             val tick = nextTick(
-                tablistService.templates(),
+                TablistService.templates(),
                 ZonedDateTime.now(),
                 tablistConfig.unknownPlaceholderRefreshSeconds.seconds
             )
 
             delay(tick.delay)
-            tick.reason?.let { tablistService.invalidateAll(it) }
+            tick.reason?.let { TablistService.invalidateAll(it) }
         }
     }
 

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistService.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/TablistService.kt
@@ -20,8 +20,6 @@ import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.seconds
 
-val tablistService = TablistService()
-
 private val log = logger()
 
 private val tabEntryUpdateTimeout = 5.seconds
@@ -41,7 +39,7 @@ private val vanishTag = buildText {
     appendSpace()
 }
 
-class TablistService {
+object TablistService {
 
     private val entryUpdater = TabEntryUpdater<TabPlayer>(
         baseName = { player -> player.baseNameSnapshot() },

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
@@ -45,6 +45,12 @@ internal class UpdateCoalescer<T>(
     private val update: suspend (T) -> Unit
 ) {
 
+    init {
+        require(updateTimeout.isPositive()) {
+            "updateTimeout must be positive but was $updateTimeout"
+        }
+    }
+
     /**
      * Stores the current request for every key with an active update loop.
      *

--- a/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/TablistTestSupport.kt
+++ b/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/TablistTestSupport.kt
@@ -141,6 +141,8 @@ internal class TestPlayer(val name: String, override val uuid: UUID = UUID.rando
 
     override fun baseName(): Component = Component.text(name)
 
+    override suspend fun baseNameSnapshot(): Component = baseName()
+
     override suspend fun showTabEntry(name: Component, order: Int) = Unit
 
     /** The header this player is currently showing, as plain text. */

--- a/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
+++ b/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
@@ -21,6 +21,7 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -342,6 +343,13 @@ class UpdateCoalescerTest {
             )
         } finally {
             scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a timeout that is not positive is rejected on construction`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            UpdateCoalescer<String>(::runHere, updateTimeout = Duration.ZERO) {}
         }
     }
 

--- a/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/listener/PlayerListener.kt
+++ b/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/listener/PlayerListener.kt
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import dev.slne.minestom.lobby.api.event.EventRegistrar
 import dev.slne.minestom.lobby.api.extension.addListener
 import dev.slne.surf.tab.core.client.service.TablistUpdateReason
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import dev.slne.surf.tab.minestom.platform.MinestomTabPlayer
 import net.minestom.server.event.Event
 import net.minestom.server.event.EventNode
@@ -18,14 +18,14 @@ class PlayerListener @Inject constructor() : EventRegistrar {
 
             val player = MinestomTabPlayer(event.player)
 
-            tablistService.invalidatePlayer(player)
-            tablistService.requestFormat(player)
-            tablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
+            TablistService.invalidatePlayer(player)
+            TablistService.requestFormat(player)
+            TablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
         }
 
         node.addListener<PlayerDisconnectEvent> { event ->
-            tablistService.forget(event.player.uuid)
-            tablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
+            TablistService.forget(event.player.uuid)
+            TablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
         }
     }
 }

--- a/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/listener/PlaytimeListener.kt
+++ b/surf-tab-minestom/src/main/kotlin/dev/slne/surf/tab/minestom/listener/PlaytimeListener.kt
@@ -4,7 +4,7 @@ import com.google.inject.Inject
 import dev.slne.minestom.lobby.api.event.EventRegistrar
 import dev.slne.minestom.lobby.api.extension.addListener
 import dev.slne.surf.playtime.api.minestom.event.AfkStateChangeEvent
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import dev.slne.surf.tab.minestom.platform.MinestomTabPlayer
 import net.minestom.server.event.Event
 import net.minestom.server.event.EventNode
@@ -15,7 +15,7 @@ import net.minestom.server.event.EventNode
 class PlaytimeListener @Inject constructor() : EventRegistrar {
     override fun register(node: EventNode<Event>) {
         node.addListener<AfkStateChangeEvent> { event ->
-            tablistService.requestFormat(MinestomTabPlayer(event.player))
+            TablistService.requestFormat(MinestomTabPlayer(event.player))
         }
     }
 }

--- a/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/PlayerListener.kt
+++ b/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/PlayerListener.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.tab.paper.listener
 
 import dev.slne.surf.tab.core.client.service.TablistUpdateReason
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import dev.slne.surf.tab.paper.platform.PaperTabPlayer
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -15,21 +15,21 @@ object PlayerListener : Listener {
     fun onJoin(event: PlayerJoinEvent) {
         val player = PaperTabPlayer(event.player)
 
-        tablistService.invalidatePlayer(player)
-        tablistService.requestFormat(player)
-        tablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
+        TablistService.invalidatePlayer(player)
+        TablistService.requestFormat(player)
+        TablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
     }
 
     @EventHandler
     fun onQuit(event: PlayerQuitEvent) {
-        tablistService.forget(event.player.uniqueId)
-        tablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
+        TablistService.forget(event.player.uniqueId)
+        TablistService.invalidateAll(TablistUpdateReason.PLAYER_COUNT)
     }
 
     @EventHandler
     fun onShow(event: PlayerShowEntityEvent) {
         val target = event.entity as? Player ?: return
 
-        tablistService.requestFormat(PaperTabPlayer(target))
+        TablistService.requestFormat(PaperTabPlayer(target))
     }
 }

--- a/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/PlaytimeListener.kt
+++ b/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/PlaytimeListener.kt
@@ -1,7 +1,7 @@
 package dev.slne.surf.tab.paper.listener
 
 import dev.slne.surf.playtime.api.paper.event.AfkStateChangeEvent
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import dev.slne.surf.tab.paper.platform.PaperTabPlayer
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
@@ -12,6 +12,6 @@ object PlaytimeListener : Listener {
     fun onAfkChange(event: AfkStateChangeEvent) {
         val player = Bukkit.getPlayer(event.playerUuid) ?: return
 
-        tablistService.requestFormat(PaperTabPlayer(player))
+        TablistService.requestFormat(PaperTabPlayer(player))
     }
 }

--- a/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/VanishListener.kt
+++ b/surf-tab-paper/src/main/kotlin/dev/slne/surf/tab/paper/listener/VanishListener.kt
@@ -1,6 +1,6 @@
 package dev.slne.surf.tab.paper.listener
 
-import dev.slne.surf.tab.core.client.service.tablistService
+import dev.slne.surf.tab.core.client.service.TablistService
 import dev.slne.surf.tab.paper.platform.PaperTabPlayer
 import dev.slne.surf.vanish.api.event.PlayerNickEvent
 import dev.slne.surf.vanish.api.event.PlayerReappearEvent
@@ -26,6 +26,6 @@ object VanishListener : Listener {
     private fun requestFormat(player: Player?) {
         if (player == null) return
 
-        tablistService.requestFormat(PaperTabPlayer(player))
+        TablistService.requestFormat(PaperTabPlayer(player))
     }
 }


### PR DESCRIPTION
- replace the top-level tablistService val with an object TablistService declaration
- top-level properties initialize in declaration order, so the instance captured tabEntryUpdateTimeout and clanLookupTimeout before assignment, reading both as Duration.ZERO
- a zero timeout made withTimeoutOrNull return null without running the update, so entries were never rebuilt and every pass reported a timeout immediately
- update all call sites in hooks, listeners, scheduler and reload command to TablistService
- reject non-positive timeouts in UpdateCoalescer and TabEntryUpdater constructors
- add UpdateCoalescerTest case covering the rejected Duration.ZERO timeout
- implement the missing baseNameSnapshot override in TestPlayer