### PR TITLE
🐛 fix(tablist): abandon update passes that outlive their timeout instead of awaiting them

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.2.6
+version=1.2.7

--- a/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
+++ b/surf-tab-core-client/src/main/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescer.kt
@@ -1,8 +1,15 @@
 package dev.slne.surf.tab.core.client.service
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -137,15 +144,22 @@ internal class UpdateCoalescer<T>(
 
         while (true) {
             try {
+                val failure = AtomicReference<Throwable>()
+                val pass = startPass(current.target, failure)
+
                 val completed = withTimeoutOrNull(updateTimeout) {
-                    update(current.target)
+                    pass.join()
                     true
                 }
 
                 if (completed == null) {
+                    pass.cancel()
+
                     runCatching {
                         onTimeout(key, current.target)
                     }
+                } else {
+                    failure.get()?.let { throw it }
                 }
             } catch (throwable: Throwable) {
                 giveUp(key, current)
@@ -159,6 +173,25 @@ internal class UpdateCoalescer<T>(
 
             current = inFlight.getValue(key)
         }
+    }
+
+    private suspend fun startPass(target: T, failure: AtomicReference<Throwable>): Job {
+        val context = currentCoroutineContext()
+        val supervisor = SupervisorJob(context[Job])
+
+        val pass = CoroutineScope(context + supervisor).launch {
+            try {
+                update(target)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (throwable: Throwable) {
+                failure.set(throwable)
+            }
+        }
+
+        supervisor.complete()
+
+        return pass
     }
 
     /**

--- a/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
+++ b/surf-tab-core-client/src/test/kotlin/dev/slne/surf/tab/core/client/service/UpdateCoalescerTest.kt
@@ -21,6 +21,7 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.suspendCoroutine
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -258,6 +259,36 @@ class UpdateCoalescerTest {
 
             assertEquals("stuck", withTimeout(1.seconds) { timedOut.await() })
             assertEquals("newest", withTimeout(1.seconds) { newestApplied.await() })
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `an update immune to cancellation does not wedge the key`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val timedOut = CompletableDeferred<Unit>()
+        val applied = CompletableDeferred<String>()
+
+        try {
+            val coalescer = UpdateCoalescer<String>(
+                runUpdates = { block -> scope.launch { block() } },
+                updateTimeout = 50.milliseconds,
+                onTimeout = { _, _ -> timedOut.complete(Unit) },
+                update = { target ->
+                    if (target == "leaked") {
+                        suspendCoroutine {}
+                    } else {
+                        applied.complete(target)
+                    }
+                }
+            )
+
+            coalescer.request(key, "leaked")
+            withTimeout(1.seconds) { timedOut.await() }
+            coalescer.request(key, "after")
+
+            assertEquals("after", withTimeout(1.seconds) { applied.await() })
         } finally {
             scope.cancel()
         }


### PR DESCRIPTION
- run each update pass as its own supervised job and await it with Job.join inside the timeout
- a pass whose continuation leaked into a scheduler that never runs it - the entity scheduler of a retired player does exactly this - cannot be unwound by cancellation, so awaiting the update directly kept the key occupied forever and silently absorbed every later request for that UUID, surviving rejoins and reloads without any log output
- cancel and abandon such a pass after the timeout so onTimeout fires and the loop continues with the newest request
- capture non-cancellation failures of a pass and rethrow them in the loop, preserving the previous error propagation
- add a regression test with a cancellation-immune update (suspendCoroutine {}) verifying the key does not wedge and the next request still runs